### PR TITLE
Remove rcParams that has no effect

### DIFF
--- a/VoiceTransformer/VoiceTransformer.ipynb
+++ b/VoiceTransformer/VoiceTransformer.ipynb
@@ -38,8 +38,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.rcParams[\"figure.figsize\"] = (14,4)\n",
-    "plt.rcParams['image.cmap'] = 'tab10'"
+    "plt.rcParams[\"figure.figsize\"] = (14,4)"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib
+matplotlib>=2
 numpy
 scipy
 IPython


### PR DESCRIPTION
This is really nitpicking, but in fact, I found out that the setting I added has no effect. However, in the matplotlib version 2 and above, the tab10 is the default colormap, and the normal 'r', 'g', 'b' convention has been changed to blue, orange, etc. 